### PR TITLE
Fix regression when very few cookbook versions exist

### DIFF
--- a/lib/chef/knife/retention_cookbook.rb
+++ b/lib/chef/knife/retention_cookbook.rb
@@ -97,7 +97,7 @@ class Chef
 
       def save_some_versions(versions, extra_versions)
         # Just removes the top X which since we sort is the top X newest versions
-        versions.slice(0, versions.length - extra_versions)
+        Array(versions.slice(0, versions.length - extra_versions))
       end
 
       def cookbook_versions(cookbook_name)


### PR DESCRIPTION
```
knife cookbook retention <cookbook>
Running in Evaluation Mode no cookbooks will be deleted
Keeping the top 1 unused versions
Latest Version: 1.0.0
ERROR: knife encountered an unexpected error
This may be a bug in the 'cookbook retention' knife command or plugin
Please collect the output of this command with the `-VV` option before filing a bug report.
Exception: NoMethodError: undefined method `each' for nil:NilClass
```

This error occurs when there are a couple versions of the cookbook