### PR TITLE
Fix cookbook version sorting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gemspec
 
 group :development do
   gem "bundler", "~> 1.6"
+  gem "github_changelog_generator", "~> 1.13"
   gem "rake", "~> 11.1"
   gem "rubocop", "~> 0.38"
-  gem "github_changelog_generator", "~> 1.13"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Import other external rake tasks
 Dir.glob("tasks/*.rake").each { |r| import r }
 

--- a/knife-chef-retention.gemspec
+++ b/knife-chef-retention.gemspec
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-$LOAD_PATH.push File.expand_path("../lib", __FILE__)
+
+$LOAD_PATH.push File.expand_path("lib", __dir__)
 require "knife-chef-retention/version"
 
 Gem::Specification.new do |s|

--- a/lib/chef/knife/retention_cookbook.rb
+++ b/lib/chef/knife/retention_cookbook.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "chef/knife"
 
 class Chef
@@ -23,6 +24,13 @@ class Chef
              long: "--extra-versions VALUE",
              description: "The number of extra versions to keep (Default: 1)",
              default: 1
+
+      option :ignore_used,
+             short: "-i",
+             long: "--ignore-used",
+             description: "Ignore used cookbooks, useful where stale inventory is a thing",
+             boolean: true,
+             default: false
 
       def run
         cookbook_name = name_args[0] if name_args.length.positive?
@@ -89,9 +97,8 @@ class Chef
         unused_versions = cookbook_versions(cookbook).take_while do |version|
           # These are package that are not used and are considered old as they
           # are after the first used version still
-          version unless version[:used]
+          version unless version[:used] && !config[:ignore_used]
         end
-
         save_some_versions(unused_versions, extra_versions)
       end
 

--- a/lib/chef/knife/retention_cookbook.rb
+++ b/lib/chef/knife/retention_cookbook.rb
@@ -110,8 +110,7 @@ class Chef
             used: used_by_node
           }
         end
-
-        versions.sort_by { |v| v[:version] }
+        versions.sort { |x, y| Gem::Version.new(x[:version]) <=> Gem::Version.new(y[:version]) }
       end
 
       def search_nodes(query)

--- a/lib/knife-chef-retention/version.rb
+++ b/lib/knife-chef-retention/version.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Knife
   module ChefRetention
     VERSION = "0.2.0"

--- a/tasks/changelog.rake
+++ b/tasks/changelog.rake
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 begin
   require "knife-chef-retention/version"
   require "github_changelog_generator/task"
@@ -6,9 +7,9 @@ begin
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
     config.future_release = "v#{Knife::ChefRetention::VERSION}"
     config.issues = false
-    config.enhancement_labels = %w(enhancement)
-    config.bug_labels = %w(bug)
-    config.exclude_labels = %w(no_changelog)
+    config.enhancement_labels = %w[enhancement]
+    config.bug_labels = %w[bug]
+    config.exclude_labels = %w[no_changelog]
   end
 rescue LoadError
   puts "Problem loading gems please install chef and github_changelog_generator"


### PR DESCRIPTION
when sorting cast and compare version objects rather than assuming its a string.

fixes #6 

Also added `--ignored-used` flag to return the list of cookbooks regardless if they are in use.

While this might sound like a bad idea in my org we unfortunately have stale inventory and therefore old versions of cookbooks will never get deleted because they were never removed from the chef server. While doing some testing/validation that the sorting worked as intended I noticed some odd behavior and traced it down to this and validated that the output matches what I see with the plugin I currently maintain when using the new flag.

Signed-off-by: Ben Abrams <me@benabrams.it>